### PR TITLE
Update examples for global sample-rate API

### DIFF
--- a/examples/02_play_wav.py
+++ b/examples/02_play_wav.py
@@ -26,19 +26,20 @@ def play_wav():
     # Load the WAV file
     source_stream = WavReaderPE(str(WAV_FILE))
 
-    # Get file info (file_sample_rate is available before configuration)
+    # Get file info and align the global sample rate to the file's rate
+    # before constructing any downstream PEs.
     file_sr = source_stream.file_sample_rate
+    pg.set_sample_rate(file_sr)
     print(f"  Channels: {source_stream.channel_count()}", flush=True)
     print(f"  Sample rate: {file_sr} Hz", flush=True)
 
-    # Now we can get extent (sample rate is set globally before construction)
     extent = source_stream.extent()
     duration_samples = extent.end - extent.start
     duration_seconds = duration_samples / file_sr
     print(f"  Duration: {duration_seconds:.2f} seconds ({duration_samples} samples)", flush=True)
 
     print(f"Playing...", flush=True)
-    pg.play(pg.GainPE(source_stream, gain=1.67), sample_rate=file_sr)
+    pg.play(pg.GainPE(source_stream, gain=1.67))
 
     print("Done!", flush=True)
 

--- a/examples/06_autowah.py
+++ b/examples/06_autowah.py
@@ -41,9 +41,10 @@ def demo_original():
     print(f"Part 1: Original signal (looped djembe) - {DURATION_SECONDS}s", flush=True)
     source_stream = WavReaderPE(str(WAV_FILE))
     sample_rate = source_stream.file_sample_rate
+    pg.set_sample_rate(sample_rate)
     duration_samples = int(DURATION_SECONDS * sample_rate)
     looped_stream = LoopPE(source_stream, crossfade_seconds=0.01)
-    pg.play(pg.GainPE(CropPE(looped_stream, 0, duration_samples), gain=0.89), sample_rate)
+    pg.play(pg.GainPE(CropPE(looped_stream, 0, duration_samples), gain=0.89))
 
 
 def demo_autowah():
@@ -61,6 +62,7 @@ def demo_autowah():
 
     source_stream = WavReaderPE(str(WAV_FILE))
     sample_rate = source_stream.file_sample_rate
+    pg.set_sample_rate(sample_rate)
     duration_samples = int(DURATION_SECONDS * sample_rate)
     looped_stream = LoopPE(source_stream, crossfade_seconds=0.01)
 
@@ -80,7 +82,7 @@ def demo_autowah():
         mode=BiquadMode.LOWPASS
     )
     output_stream = GainPE(filtered_stream, gain=1.0)
-    pg.play(pg.GainPE(CropPE(output_stream, 0, duration_samples), gain=0.50), sample_rate)
+    pg.play(pg.GainPE(CropPE(output_stream, 0, duration_samples), gain=0.50))
 
 
 def demo_svfilter_autowah():
@@ -98,6 +100,7 @@ def demo_svfilter_autowah():
 
     source_stream = WavReaderPE(str(WAV_FILE))
     sample_rate = source_stream.file_sample_rate
+    pg.set_sample_rate(sample_rate)
     duration_samples = int(DURATION_SECONDS * sample_rate)
     looped_stream = LoopPE(source_stream, crossfade_seconds=0.01)
 
@@ -117,7 +120,7 @@ def demo_svfilter_autowah():
         mode=BiquadMode.LOWPASS
     )
     output_stream = GainPE(filtered_stream, gain=1.0)
-    pg.play(pg.GainPE(CropPE(output_stream, 0, duration_samples), gain=0.50), sample_rate)
+    pg.play(pg.GainPE(CropPE(output_stream, 0, duration_samples), gain=0.50))
 
 
 DEMOS = [

--- a/examples/07_soft_clipping.py
+++ b/examples/07_soft_clipping.py
@@ -53,7 +53,7 @@ def clean_signal():
     clean = GainPE(source, gain=0.5)
     clean_out = CropPE(clean, 0, (DURATION_SAMPLES) - (0))
 
-    pg.play(pg.GainPE(clean_out, gain=0.90), SAMPLE_RATE)
+    pg.play(pg.GainPE(clean_out, gain=0.90))
 
 def light_saturation():
     # --- Part 2: Light saturation ---
@@ -66,7 +66,7 @@ def light_saturation():
     output_light = GainPE(saturated_light, gain=0.6)
     output_light = CropPE(output_light, 0, (DURATION_SAMPLES) - (0))
 
-    pg.play(pg.GainPE(output_light, gain=0.90), SAMPLE_RATE)
+    pg.play(pg.GainPE(output_light, gain=0.90))
 
 def heavy_saturation():
     # --- Part 3: Heavy saturation ---
@@ -77,7 +77,7 @@ def heavy_saturation():
     output_heavy = GainPE(saturated_heavy, gain=0.5)
     output_heavy = CropPE(output_heavy, 0, (DURATION_SAMPLES) - (0))
 
-    pg.play(pg.GainPE(output_heavy, gain=1.00), SAMPLE_RATE)
+    pg.play(pg.GainPE(output_heavy, gain=1.00))
 
 def asymmetric_clipping():
     # --- Part 4: Asymmetric clipping (more "character") ---
@@ -97,7 +97,7 @@ def asymmetric_clipping():
     output_asym = GainPE(saturated_asym, gain=0.6)
     output_asym = CropPE(output_asym, 0, (DURATION_SAMPLES) - (0))
 
-    pg.play(pg.GainPE(output_asym, gain=0.84), SAMPLE_RATE)
+    pg.play(pg.GainPE(output_asym, gain=0.84))
 
 DEMOS = [
     ("Clean signal", clean_signal),

--- a/examples/11_dynamics.py
+++ b/examples/11_dynamics.py
@@ -53,6 +53,7 @@ def demo_sidechain_ducking():
     
     bass_stream = WavReaderPE(str(BASS_FILE))
     sample_rate = bass_stream.file_sample_rate
+    pg.set_sample_rate(sample_rate)
     kick_stream = WavReaderPE(str(KICK_FILE))
 
     # loop the kick to keep time with the bass
@@ -91,7 +92,6 @@ def demo_sidechain_ducking():
     extent = bass_stream.extent()
     pg.play(
         pg.GainPE(CropPE(mix_stream, extent.start or 0, extent.end - (extent.start or 0)), gain=0.85),
-        sample_rate=sample_rate,
     )
     print()
 
@@ -109,7 +109,8 @@ def demo_sidechain_ducking_voice():
     music_stream = WavReaderPE(str(MUSIC_FILE))
     voice_stream = WavReaderPE(str(VOICE_FILE))
     sample_rate = voice_stream.file_sample_rate
-    
+    pg.set_sample_rate(sample_rate)
+
     # Create envelope from voice
     voice_detector_stream = EnvelopePE(
         voice_stream,
@@ -137,7 +138,7 @@ def demo_sidechain_ducking_voice():
     print("Music ducks during voice portions.")
     print()
     
-    pg.play(pg.GainPE(mix_stream, gain=4.73), sample_rate)
+    pg.play(pg.GainPE(mix_stream, gain=4.73))
     print()
 
 
@@ -153,7 +154,8 @@ def demo_expander():
 
     source_stream = WavReaderPE(str(BASS_FILE))
     sample_rate = source_stream.file_sample_rate
-    
+    pg.set_sample_rate(sample_rate)
+
     # Create envelope follower
     env_stream = EnvelopePE(source_stream, attack=0.01, release=0.1)
     
@@ -171,7 +173,7 @@ def demo_expander():
     print("Quiet parts become even quieter.")
     print()
     
-    pg.play(pg.GainPE(expanded_stream, gain=0.67), sample_rate)
+    pg.play(pg.GainPE(expanded_stream, gain=0.67))
     print()
 
 
@@ -188,7 +190,8 @@ def demo_custom_envelope():
     
     pad_stream = WavReaderPE(str(MUSIC_FILE))
     sample_rate = pad_stream.file_sample_rate
-    
+    pg.set_sample_rate(sample_rate)
+
     # Custom control signal: slow triangle-ish LFO
     # This creates rhythmic "breathing" independent of input level
     lfo_freq = 3
@@ -212,7 +215,7 @@ def demo_custom_envelope():
     print("Creates rhythmic 'breathing' effect")
     print()
     
-    pg.play(pg.GainPE(rhythmic_stream, gain=4.95), sample_rate)
+    pg.play(pg.GainPE(rhythmic_stream, gain=4.95))
     print()
 
 

--- a/examples/12_audio_library.py
+++ b/examples/12_audio_library.py
@@ -28,19 +28,23 @@ print(f"Resolved '{LOOP_PATTERN}': {loop_path}", flush=True)
 
 source_stream = WavReaderPE(sound_path)
 loop_source_stream = WavReaderPE(loop_path)
+
+# Align the global rate to the file's native rate before building downstream PEs.
+file_sr = source_stream.file_sample_rate
+pg.set_sample_rate(file_sr)
+
 looped_stream = LoopPE(loop_source_stream, count=LOOP_COUNT)
 mixed_stream = MixPE(
-    source_stream, 
-    DelayPE(source_stream, delay=loop_source_stream.extent().end), 
-    DelayPE(source_stream, delay=2 * loop_source_stream.extent().end), 
-    DelayPE(source_stream, delay=3 * loop_source_stream.extent().end), 
+    source_stream,
+    DelayPE(source_stream, delay=loop_source_stream.extent().end),
+    DelayPE(source_stream, delay=2 * loop_source_stream.extent().end),
+    DelayPE(source_stream, delay=3 * loop_source_stream.extent().end),
     looped_stream)
-file_sr = source_stream.file_sample_rate
 
 extent = mixed_stream.extent()
 duration_samples = extent.end - extent.start
 duration_seconds = duration_samples / file_sr
 print(f"Playing {duration_seconds:.2f} seconds...", flush=True)
-pg.play(mixed_stream, sample_rate=file_sr)
+pg.play(mixed_stream)
 
 print("Done!", flush=True)

--- a/examples/15_reverse_pitch_echo.py
+++ b/examples/15_reverse_pitch_echo.py
@@ -30,6 +30,9 @@ print(f"Loading: {WAV_FILE}", flush=True)
 
 source_stream = WavReaderPE(str(WAV_FILE))
 sample_rate = source_stream.file_sample_rate or 44100
+# Align the global rate to the file's native rate before any downstream
+# PEs are constructed (CropPE, GainPE, ReversePitchEchoPE, ...).
+pg.set_sample_rate(sample_rate)
 duration_samples = int(DURATION_SECONDS * sample_rate)
 
 def original_signal():
@@ -37,7 +40,7 @@ def original_signal():
     print(f"\nPart 1: Dry signal - {DURATION_SECONDS}s", flush=True)
     dry_stream = CropPE(source_stream, 0, (duration_samples) - (0))
 
-    pg.play(pg.GainPE(dry_stream, gain=2.14), sample_rate)
+    pg.play(pg.GainPE(dry_stream, gain=2.14))
 
 def wet_only():
     # --- Part 2: Wet only ---
@@ -52,7 +55,7 @@ def wet_only():
     wet_stream = GainPE(wet_stream, gain=0.8)
     wet_out_stream = CropPE(wet_stream, 0, (duration_samples) - (0))
 
-    pg.play(pg.GainPE(wet_out_stream, gain=2.28), sample_rate)
+    pg.play(pg.GainPE(wet_out_stream, gain=2.28))
 
 def wet_plus_dry():
     # --- Part 3: Dry + wet mix ---
@@ -67,7 +70,7 @@ def wet_plus_dry():
     mixed_stream = MixPE(GainPE(source_stream, gain=0.5), GainPE(wet_mix_stream, gain=0.5))
     mixed_out_stream = CropPE(mixed_stream, 0, (duration_samples) - (0))
 
-    pg.play(pg.GainPE(mixed_out_stream, gain=2.83), sample_rate)
+    pg.play(pg.GainPE(mixed_out_stream, gain=2.83))
 
 DEMOS = [
     ("Original signal", original_signal),

--- a/examples/20_alternative_temperaments.py
+++ b/examples/20_alternative_temperaments.py
@@ -250,7 +250,7 @@ def play_chord_comparison(chord_name, notes, gain=1.0):
     print("Listen for the differences in consonance and beating.")
     print(f"{'='*60}\n")
     
-    pg.play(pg.GainPE(mixed, gain=gain), sample_rate=SAMPLE_RATE)
+    pg.play(pg.GainPE(mixed, gain=gain))
 
     print("\n✅ Playback complete!\n")
 
@@ -331,7 +331,7 @@ def demo_reference_frequency():
         print(f"\nPlaying {total_duration:.1f} seconds...")
         print("Listen for the subtle pitch difference.\n")
         
-        pg.play(pg.GainPE(mixed, gain=2.51), sample_rate=SAMPLE_RATE)
+        pg.play(pg.GainPE(mixed, gain=2.51))
 
         print("\n✅ Playback complete!\n")
 

--- a/examples/20_timewarp.py
+++ b/examples/20_timewarp.py
@@ -45,10 +45,13 @@ def demo_original():
 
     spoken_stream = WavReaderPE(str(SPOKEN_PATH))
     sample_rate = spoken_stream.file_sample_rate
+    pg.set_sample_rate(sample_rate)
 
     output_stream = GainPE(spoken_stream, gain=0.8)
 
-    pg.play(pg.GainPE(output_stream, gain=2.67), sample_rate)
+    pg.play(pg.GainPE(output_stream, gain=2.67))
+
+
 def demo_fixed_rate():
     """
     Play a spoken sample at a fixed rate (1.5x).
@@ -59,11 +62,14 @@ def demo_fixed_rate():
 
     spoken_stream = WavReaderPE(str(SPOKEN_PATH))
     sample_rate = spoken_stream.file_sample_rate
+    pg.set_sample_rate(sample_rate)
 
     warped_stream = TimeWarpPE(spoken_stream, rate=1.5)
     output_stream = GainPE(warped_stream, gain=0.8)
 
-    pg.play(pg.GainPE(output_stream, gain=2.67), sample_rate)
+    pg.play(pg.GainPE(output_stream, gain=2.67))
+
+
 def demo_accelerating_loop():
     """
     Loop the spoken sample and accelerate from 0.5x to 5.0x over 10 seconds.
@@ -74,6 +80,7 @@ def demo_accelerating_loop():
 
     spoken_stream = WavReaderPE(str(SPOKEN_PATH))
     sample_rate = spoken_stream.file_sample_rate
+    pg.set_sample_rate(sample_rate)
 
     # Loop the entire sample forever (with a small crossfade to reduce clicks)
     looped_stream = LoopPE(spoken_stream, crossfade_seconds=0.01)
@@ -87,7 +94,9 @@ def demo_accelerating_loop():
     output_stream = GainPE(warped_stream, gain=0.8)
     output_stream = CropPE(output_stream, 0, (dur_samples) - (0))
 
-    pg.play(pg.GainPE(output_stream, gain=2.67), sample_rate)
+    pg.play(pg.GainPE(output_stream, gain=2.67))
+
+
 def demo_jog_shuttle():
     """
     Play at decreasing speeds, eventually going negative.
@@ -98,6 +107,7 @@ def demo_jog_shuttle():
 
     drums_stream = WavReaderPE(str(DRUMS_PATH))
     sample_rate = drums_stream.file_sample_rate
+    pg.set_sample_rate(sample_rate)
 
     # Rate ramp is a PE, so TimeWarpPE's extent becomes finite (matches the rate extent).
     demo_length = int(seconds_to_samples(10, sample_rate))
@@ -107,7 +117,9 @@ def demo_jog_shuttle():
     output_stream = GainPE(warped_stream, gain=0.8)
     output_stream = CropPE(output_stream, 0, (demo_length) - (0))
 
-    pg.play(pg.GainPE(output_stream, gain=1.11), sample_rate)
+    pg.play(pg.GainPE(output_stream, gain=1.11))
+
+
 DEMOS = [
     ("Original", demo_original),
     ("Fixed Rate (1.5x)", demo_fixed_rate),

--- a/examples/23_convolution.py
+++ b/examples/23_convolution.py
@@ -142,7 +142,7 @@ def _demo_dry(source_path: Path, *, gain: float = 0.8, norm_gain: float = 1.0) -
     print("IR:     (dry)")
     print()
 
-    pg.play(pg.GainPE(out_stream, gain=norm_gain), sample_rate)
+    pg.play(pg.GainPE(out_stream, gain=norm_gain))
 
 
 def _demo_wet(
@@ -200,7 +200,7 @@ def _demo_wet(
     print(f"Wet gain: {wet_gain:.2f} (effective: {wet_gain / ir_energy:.4f})")
     print()
 
-    pg.play(pg.GainPE(out_stream, gain=norm_gain), sample_rate)
+    pg.play(pg.GainPE(out_stream, gain=norm_gain))
 
 
 def _demo_wet_chorus_on_wet(
@@ -254,7 +254,7 @@ def _demo_wet_chorus_on_wet(
     )
     print()
 
-    pg.play_offline(pg.GainPE(out_stream, gain=norm_gain), sample_rate)
+    pg.play_offline(pg.GainPE(out_stream, gain=norm_gain))
 
 def demo_spoken_dry():
     print("=== Demo: spoken voice (dry) ===")

--- a/examples/33_piecewise.py
+++ b/examples/33_piecewise.py
@@ -58,31 +58,31 @@ def _make_triad(transition_type: TransitionType):
 def demo_step():
     """Step: instant pitch changes (no glide)."""
     print("=== Piecewise 33: STEP (instant pitch changes) ===")
-    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.STEP), 0, DURATION_SAMPLES), gain=2.00), SAMPLE_RATE)
+    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.STEP), 0, DURATION_SAMPLES), gain=2.00))
 
 
 def demo_linear():
     """Linear: constant-rate glide between notes."""
     print("=== Piecewise 33: LINEAR (constant glide between notes) ===")
-    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.LINEAR), 0, DURATION_SAMPLES), gain=2.00), SAMPLE_RATE)
+    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.LINEAR), 0, DURATION_SAMPLES), gain=2.00))
 
 
 def demo_exponential():
     """Exponential: pitch glides with exponential curve."""
     print("=== Piecewise 33: EXPONENTIAL (exponential pitch glide) ===")
-    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.EXPONENTIAL), 0, DURATION_SAMPLES), gain=2.00), SAMPLE_RATE)
+    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.EXPONENTIAL), 0, DURATION_SAMPLES), gain=2.00))
 
 
 def demo_sigmoid():
     """Sigmoid: S-curve glide (slow at note boundaries)."""
     print("=== Piecewise 33: SIGMOID (S-curve glide) ===")
-    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.SIGMOID), 0, DURATION_SAMPLES), gain=2.00), SAMPLE_RATE)
+    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.SIGMOID), 0, DURATION_SAMPLES), gain=2.00))
 
 
 def demo_constant_power():
     """Constant-power: sin/cos-style curve between notes."""
     print("=== Piecewise 33: CONSTANT_POWER (sin/cos-style glide) ===")
-    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.CONSTANT_POWER), 0, DURATION_SAMPLES), gain=2.00), SAMPLE_RATE)
+    pg.play(pg.GainPE(CropPE(_make_triad(TransitionType.CONSTANT_POWER), 0, DURATION_SAMPLES), gain=2.00))
 
 
 DEMOS = [

--- a/examples/37_sequence_eg.py
+++ b/examples/37_sequence_eg.py
@@ -17,6 +17,9 @@ def _build_sources():
     choir_path = audio_dir / "choir.wav"
     source = pg.WavReaderPE(str(choir_path))
     sample_rate = source.file_sample_rate or 44100
+    # Align the global rate to the file's native rate before building
+    # downstream PEs.
+    pg.set_sample_rate(sample_rate)
 
     # Original choir
     choir = source
@@ -43,7 +46,7 @@ def demo_overlap():
         (choir_up, int(2.0 * sample_rate)),
         mode=pg.SequenceMode.OVERLAP,
     )
-    pg.play(pg.GainPE(pg.CropPE(seq, 0, int(3.5 * sample_rate)), gain=2.54), sample_rate)
+    pg.play(pg.GainPE(pg.CropPE(seq, 0, int(3.5 * sample_rate)), gain=2.54))
 
 
 def demo_non_overlap():
@@ -57,7 +60,7 @@ def demo_non_overlap():
         (choir_up, int(2.0 * sample_rate)),
         mode=pg.SequenceMode.NON_OVERLAP,
     )
-    pg.play(pg.GainPE(pg.CropPE(seq, 0, int(3.5 * sample_rate)), gain=4.07), sample_rate)
+    pg.play(pg.GainPE(pg.CropPE(seq, 0, int(3.5 * sample_rate)), gain=4.07))
 
 
 DEMOS = [

--- a/examples/demo_asset_manager.py
+++ b/examples/demo_asset_manager.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from examples_helper import run_demos
 
 from pygmu2.asset_manager import (
+    AssetLoadFailed,
     AssetManager,
     GoogleDriveAssetLoader,
     GithubUserContentAssetLoader,
@@ -47,14 +48,17 @@ def demo_google_drive_giant_fish():
     manager = AssetManager(asset_loader=loader)
 
     asset_spec = "GiantFish/SegmentedVoice/N2_1?.wav"
-    # List all matching assets (returns cache-relative paths)
-    remote_assets = manager.list_remote_assets(asset_spec)
-    print(f"Google Drive matches for {asset_spec!r}: {len(remote_assets)}")
-    for asset in remote_assets:
-        print(f"  - {asset}")
-    # Return the first matching asset, reload even if in cache.
-    path = manager.load_asset(asset_spec, force=True)
-    print(f"Google Drive Giant Fish selected asset: {path}")
+    try:
+        # List all matching assets (returns cache-relative paths)
+        remote_assets = manager.list_remote_assets(asset_spec)
+        print(f"Google Drive matches for {asset_spec!r}: {len(remote_assets)}")
+        for asset in remote_assets:
+            print(f"  - {asset}")
+        # Return the first matching asset, reload even if in cache.
+        path = manager.load_asset(asset_spec, force=True)
+        print(f"Google Drive Giant Fish selected asset: {path}")
+    except AssetLoadFailed as exc:
+        print(f"Skipping Google Drive demo: {exc}")
 
 def demo_google_drive():
     # TODO: Fill in your Google Drive folder ID.
@@ -81,14 +85,17 @@ def demo_google_drive():
     manager = AssetManager(asset_loader=loader)
 
     asset_spec = "multi_samples/Anklung_Hit/Anklung_Hit*.wav"
-    # List all matching assets (returns cache-relative paths)
-    remote_assets = manager.list_remote_assets(asset_spec)
-    print(f"Google Drive matches for {asset_spec!r}: {len(remote_assets)}")
-    for asset in remote_assets:
-        print(f"  - {asset}")
-    # Return the first matching asset, loading and caching as needed.
-    path = manager.load_asset(asset_spec)
-    print(f"Google Drive selected asset: {path}")
+    try:
+        # List all matching assets (returns cache-relative paths)
+        remote_assets = manager.list_remote_assets(asset_spec)
+        print(f"Google Drive matches for {asset_spec!r}: {len(remote_assets)}")
+        for asset in remote_assets:
+            print(f"  - {asset}")
+        # Return the first matching asset, loading and caching as needed.
+        path = manager.load_asset(asset_spec)
+        print(f"Google Drive selected asset: {path}")
+    except AssetLoadFailed as exc:
+        print(f"Skipping Google Drive demo: {exc}")
 
 
 def demo_github():
@@ -107,14 +114,17 @@ def demo_github():
     manager = AssetManager(asset_loader=loader)
 
     asset_spec = "SOBR_136_Full_Drum_Loop_*.wav"
-    # List all matching assets
-    remote_assets = manager.list_remote_assets(asset_spec)
-    print(f"GitHub matches for {asset_spec!r}: {len(remote_assets)}")
-    for asset in remote_assets:
-        print(f"  - {asset}")
-    # Return the first matching asset, loading and caching as needed.
-    path = manager.load_asset(asset_spec)
-    print(f"GitHub selected asset: {path}")
+    try:
+        # List all matching assets
+        remote_assets = manager.list_remote_assets(asset_spec)
+        print(f"GitHub matches for {asset_spec!r}: {len(remote_assets)}")
+        for asset in remote_assets:
+            print(f"  - {asset}")
+        # Return the first matching asset, loading and caching as needed.
+        path = manager.load_asset(asset_spec)
+        print(f"GitHub selected asset: {path}")
+    except AssetLoadFailed as exc:
+        print(f"Skipping GitHub demo: {exc}")
 
 DEMOS = [
     ("Google Drive Giant Fish Demo", demo_google_drive_giant_fish),

--- a/examples/envelope_filter_eg.py
+++ b/examples/envelope_filter_eg.py
@@ -62,12 +62,12 @@ HIGH_FREQ = 4000.0   # Hz — bright (loud clap / envelope near 1)
 
 def demo_claps():
     """Play claps.wav unmodified."""
-    pg.play(pg.WavReaderPE(str(CLAPS_FILE)), SRATE)
+    pg.play(pg.WavReaderPE(str(CLAPS_FILE)))
 
 
 def demo_choir():
     """Play choir.wav unmodified."""
-    pg.play(pg.WavReaderPE(str(CHOIR_FILE)), SRATE)
+    pg.play(pg.WavReaderPE(str(CHOIR_FILE)))
 
 
 def demo_envelope_filter():
@@ -113,7 +113,7 @@ def demo_envelope_filter():
     output = pg.SetExtentPE(pg.GainPE(filtered, 0.5),
                             start=0, duration=claps_end + release_samples)
 
-    pg.play(output, SRATE)
+    pg.play(output)
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/examples/im_lucky.py
+++ b/examples/im_lucky.py
@@ -233,10 +233,10 @@ cropped_hi = pg.CropPE(stem_hi, 0, duration)
 lo_path = str(stem_dir / "im_lucky_supersaw_lo.wav")
 hi_path = str(stem_dir / "im_lucky_supersaw_hi.wav")
 print(f"Rendering supersaw lo stem → {lo_path}")
-pg.render_to_file(cropped_lo, lo_path, sample_rate=SRATE)
+pg.render_to_file(cropped_lo, lo_path)
 print(f"Rendering supersaw hi stem → {hi_path}")
-pg.render_to_file(cropped_hi, hi_path, sample_rate=SRATE)
+pg.render_to_file(cropped_hi, hi_path)
 print("Stems written.")
 
 # Render and play the full mix...
-pg.browse(source=wet_mix, sample_rate=SRATE)
+pg.browse(source=wet_mix)

--- a/examples/reverb_eg.py
+++ b/examples/reverb_eg.py
@@ -38,19 +38,19 @@ def _load_sources():
 
 
 def demo_dry_only():
-    source, _ir, sample_rate = _load_sources()
-    pg.play(pg.GainPE(source, gain=0.81), sample_rate)
+    source, _ir, _sample_rate = _load_sources()
+    pg.play(pg.GainPE(source, gain=0.81))
 
 
 def demo_fixed_mix():
-    source, ir, sample_rate = _load_sources()
+    source, ir, _sample_rate = _load_sources()
 
     reverb = pg.ReverbPE(source, ir, mix=0.4, normalize_ir=True)
-    pg.play(pg.GainPE(reverb, gain=1.31), sample_rate)
+    pg.play(pg.GainPE(reverb, gain=1.31))
 
 
 def demo_ramp_mix():
-    source, ir, sample_rate = _load_sources()
+    source, ir, _sample_rate = _load_sources()
 
     extent = source.extent()
     if extent.start is None or extent.end is None:
@@ -63,7 +63,7 @@ def demo_ramp_mix():
         extend_mode=pg.ExtendMode.HOLD_LAST,
     )
     reverb = pg.ReverbPE(source, ir, mix=mix_ramp, normalize_ir=True)
-    pg.play(pg.GainPE(reverb, gain=1.08), sample_rate)
+    pg.play(pg.GainPE(reverb, gain=1.08))
 
 
 DEMOS = [

--- a/examples/tralfam_eg.py
+++ b/examples/tralfam_eg.py
@@ -101,13 +101,13 @@ def demo_padded_man_looped_tralfam():
 def demo_uke_tralfam_pitch_up():
     source = UKE_WAV
     tralfam = pg.TralfamPE(source, seed=42, normalize_peak=0.33, pitch_shift=7)
-    pg.play(pg.GainPE(tralfam, gain=1.52), SAMPLE_RATE)
+    pg.play(pg.GainPE(tralfam, gain=1.52))
 
 
 def demo_uke_tralfam_pitch_down():
     source = UKE_WAV
     tralfam = pg.TralfamPE(source, seed=42, normalize_peak=0.33, pitch_shift=-12)
-    pg.play(pg.GainPE(tralfam, gain=1.52), SAMPLE_RATE)
+    pg.play(pg.GainPE(tralfam, gain=1.52))
 
 
 DEMOS = [


### PR DESCRIPTION
## Summary
- Remove stale `sample_rate` arguments from `pg.play()`, `pg.play_offline()`, `pg.render_to_file()`, and `pg.browse()` across 16 example scripts.
- For WAV-based examples, call `pg.set_sample_rate(file_sample_rate)` before constructing downstream PEs so renderer timing and PE math stay aligned.
- Make `demo_asset_manager.py` skip gracefully when Google OAuth libraries are missing instead of crashing.

## Context
After `set_sample_rate()` became required and render helpers stopped accepting a per-call sample rate, several examples still passed the old argument and failed at runtime. All 46 active `examples/*.py` scripts were smoke-tested (NullRenderer) and pass.

## Test plan
- [ ] `uv run python examples/01_hello_sine.py 1`
- [ ] Spot-check a WAV example: `uv run python examples/02_play_wav.py 1`
- [ ] Spot-check dynamics: `uv run python examples/11_dynamics.py a`
- [ ] `uv run pytest` (if CI does not run automatically)


Made with [Cursor](https://cursor.com)